### PR TITLE
added trac_ik_kinematics_plugin dependency to package.xml

### DIFF
--- a/interbotix_moveit/package.xml
+++ b/interbotix_moveit/package.xml
@@ -22,6 +22,7 @@
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>moveit_setup_assistant</run_depend>
+  <run_depend>trac_ik_kinematics_plugin</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>


### PR DESCRIPTION
The TRAC-IK kinematics plugin which is used as a default kinematics solver was not listed as a dependency and so it was not being installed by rosdep.